### PR TITLE
Replace Alioth with Salsa

### DIFF
--- a/message.txt
+++ b/message.txt
@@ -11,8 +11,8 @@ Main-programming-language:
 Other-programming-languages: 
 
 
-# create alioth account here: https://alioth.debian.org/account/register.php
-Alioth-username: 
+# create salsa account here: https://signup.salsa.debian.org/
+Salsa-username: 
 
 
 # create Wiki account here: https://wiki.debian.org/FrontPage?action=newaccount


### PR DESCRIPTION
Alioth.debian.org will be going away soon, thus pointing students to the new salsa.debian.org service might be a good idea